### PR TITLE
feat: Add old api supports

### DIFF
--- a/src/lib/omerlo/reader/endpoints/categories.ts
+++ b/src/lib/omerlo/reader/endpoints/categories.ts
@@ -1,0 +1,50 @@
+import { type LocalesMetadata } from "$reader/utils/response";
+import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from "$reader/utils/api";
+import { requestPublisher } from "../utils/request";
+
+export const categoriesFetchers = (f: typeof fetch) => {
+  return {
+    listCategories: listCategories(f),
+    getCategory: getCategory(f)
+  }
+}
+
+export interface Category{
+  id: string;
+  svg: string;
+  name: string;
+  meta: {
+    locale: LocalesMetadata;
+  },
+  updatedAt: Date;
+}
+
+export function getCategory(f: typeof fetch) {
+  return async (id: string) => {
+    const opts = { parser: parseCategory };
+    return requestPublisher(f, `/categories/${id}`, opts);
+  }
+}
+
+export function listCategories(f: typeof fetch) {
+  return async (params?: Partial<PagingParams>) => {
+    const  queryParams = params
+    const opts = { parser: parseMany(parseCategory), queryParams };
+    return requestPublisher(f, `/categories`, opts);
+  }
+}
+
+export function parseCategory(data: ApiData, _assoc: ApiAssocs): Category {
+  return {
+    id: data.id,
+    svg: data.svg_icon,
+    name: data.localized.name,
+    updatedAt: data.updated_at,
+    meta: {
+      locale: {
+        available: [data.localized.locale],
+        current: data.localized.locale
+      }
+    }
+  }
+}

--- a/src/lib/omerlo/reader/endpoints/content-templates.ts
+++ b/src/lib/omerlo/reader/endpoints/content-templates.ts
@@ -1,0 +1,18 @@
+import type { LocalesMetadata } from "$reader/utils/response";
+
+export interface ContentTemplate {
+  id: string;
+  key: string;
+  name: string;
+  meta: {
+    locales: LocalesMetadata;
+  };
+  metadata: Record<string, string>;
+  enableFields: string[];
+  updatedAt: Date;
+}
+
+export interface ContentBlockTemplate {
+  id: string;
+  key: string;
+}

--- a/src/lib/omerlo/reader/endpoints/contents.ts
+++ b/src/lib/omerlo/reader/endpoints/contents.ts
@@ -1,0 +1,60 @@
+import type { LocalesMetadata } from "$reader/utils/response";
+import type { Category } from "./categories";
+import type { ContentBlockTemplate, ContentTemplate } from "./content-templates";
+import type { Visual } from "./visuals";
+
+export interface ContentSummary {
+  id: string;
+  template: ContentTemplate;
+  metadata: Record<string, string>;
+  canonicalDomain: string;
+  canonicalUrl: string;
+  isArchived: boolean,
+  publishedAt?: Date,
+  visibility?: string;
+  categories: Category[];
+  show_published_at: boolean;
+  updatedAt: Date;
+  meta: {
+    locales: LocalesMetadata
+  };
+  titleHtml: string;
+  titleText: string;
+  leadHtml: string;
+  leadText: string;
+  subtitleHtml: string;
+  subtitleText: string;
+  visual: Visual
+  seo: ContentSeo
+  // TODO authors
+}
+
+export interface ContentSeo {
+  title: string;
+  description: string;
+}
+
+export interface Content extends ContentSummary {
+  blocks: ContentBlock[]
+}
+
+export type ContentBlock = ContentBlockRichtext | ContentBlockData;
+
+export type ContentBlockRichtext = {
+  id: string;
+  template: ContentBlockTemplate;
+  visual?: Visual;
+  kind: 'richtext';
+  contentHtml: string
+}
+
+export type ContentBlockData = {
+  id: string;
+  template: ContentBlockTemplate;
+  visual?: Visual;
+  kind: 'data';
+  contentType: string;
+  data: unknown;
+}
+
+// TODO others content's blocks

--- a/src/lib/omerlo/reader/endpoints/notification.ts
+++ b/src/lib/omerlo/reader/endpoints/notification.ts
@@ -1,6 +1,6 @@
 import { request } from '$reader/utils/request';
 import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
-import { parseLocalesMetadata, type LocalesMetadata } from '../utils/response';
+import { parseLocalesMetadata, type LocalesMetadata } from '$reader/utils/response';
 
 export const notificationFetchers = (f: typeof fetch) => {
   return {
@@ -37,13 +37,13 @@ export interface TopicSummary {
   updatedAt: Date
 }
 
-export interface SubscribtionParams {
+export interface SubscriptionParams {
   topicId: string;
   pushToken: string;
 }
 
 export function subscribeToTopic(f: typeof fetch) {
-  return (params: SubscribtionParams) => {
+  return (params: SubscriptionParams) => {
     const body = { push_token: params.pushToken };
     const headers = new Headers({ 'Content-Type': 'application/json' });
     const opts = { body, headers, method: 'post' as const };
@@ -52,7 +52,7 @@ export function subscribeToTopic(f: typeof fetch) {
 }
 
 export function unsubscribeFromTopic(f: typeof fetch) {
-  return (params: SubscribtionParams) => {
+  return (params: SubscriptionParams) => {
     const body = { push_token: params.pushToken };
     const headers = new Headers({ 'Content-Type': 'application/json' });
     const opts = { body, headers, method: 'post' as const };

--- a/src/lib/omerlo/reader/endpoints/visuals.ts
+++ b/src/lib/omerlo/reader/endpoints/visuals.ts
@@ -1,0 +1,30 @@
+export type Visual = Image | Slideshow | Video
+
+export type Image = {
+  type: 'image'
+  url: string;
+  captionHtml: string;
+  captionText: string;
+  credit: string;
+  gravity: Gravity
+}
+
+export type Slideshow = {
+  type: 'slideshow';
+}
+
+export type Video = {
+  type: 'video';
+}
+
+export type Gravity =
+  'center' |
+  'north' |
+  'northeast' |
+  'east' |
+  'southeast' |
+  'south' |
+  'southwest' |
+  'west' |
+  'northwest';
+

--- a/src/lib/omerlo/reader/fetchers.ts
+++ b/src/lib/omerlo/reader/fetchers.ts
@@ -1,4 +1,5 @@
 import { accountsFetchers } from './endpoints/accounts';
+import { categoriesFetchers } from './endpoints/categories';
 import { deviceFetchers } from './endpoints/device';
 import { notificationFetchers } from './endpoints/notification';
 import { oauthFetchers } from './endpoints/oauth';
@@ -8,6 +9,7 @@ export const fetchers = (f: typeof fetch) => {
     ...accountsFetchers(f),
     ...deviceFetchers(f),
     ...oauthFetchers(f),
+    ...categoriesFetchers(f),
     notifications: notificationFetchers(f),
   };
 };

--- a/src/lib/omerlo/reader/server/hooks.ts
+++ b/src/lib/omerlo/reader/server/hooks.ts
@@ -55,6 +55,13 @@ export const proxyHook: Handle = async ({ event, resolve }) => {
     return await handleApiProxy({ event, resolve });
   }
 
+  // TODO remove once every API will be done in Reader
+  if (event.url.pathname.startsWith('/api/publisher')) {
+    const mediaId = env.PRIVATE_OMERLO_MEDIA_ID;
+    event.url.pathname = event.url.pathname.replace('/api/publisher/', `/api/public/publisher/v2/medias/${mediaId}/`);
+    return handleApiProxy({ event, resolve });
+  }
+
   return resolve(event);
 }
 

--- a/src/lib/omerlo/reader/utils/request.ts
+++ b/src/lib/omerlo/reader/utils/request.ts
@@ -75,3 +75,41 @@ export async function dirtyRequest(
 
   return resp;
 }
+
+/**
+  * NOTE: This is for OLD api and will be removed once every API will
+  * be developped in Reader.
+  */
+
+export async function requestPublisher<T>(
+  f: typeof fetch,
+  path: string,
+  opts: Partial<FetchOptions<T>>
+): Promise<ApiResponse<T>> {
+  const { body, headers, method, queryParams, parser } = parseRequestOpts(opts);
+
+  return dirtyRequestPublisher(f, path, { body, headers, method, queryParams }).then(async (resp) => {
+    return parseApiResponse(resp, parser);
+  });
+}
+
+export async function dirtyRequestPublisher(
+  f: typeof fetch,
+  path: string,
+  opts: DirtyFetchOptions
+): Promise<Response> {
+  const queryParams = new URLSearchParams()
+
+  path = `/api/publisher/${path}`;
+
+  if (opts?.queryParams) {
+    Object.entries(opts.queryParams).forEach(([key, value]) => {
+      queryParams.append(key, String(value));
+    });
+
+    path = `${path}?${queryParams}`;
+  }
+
+  return f(path.toString(), opts);
+}
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,3 @@
-import aspectRatio from '@tailwindcss/aspect-ratio';
 import containerQueries from '@tailwindcss/container-queries';
 import forms from '@tailwindcss/forms';
 import typography from '@tailwindcss/typography';
@@ -11,5 +10,5 @@ export default {
     extend: {}
   },
 
-  plugins: [typography, forms, containerQueries, aspectRatio]
+  plugins: [typography, forms, containerQueries]
 } satisfies Config;


### PR DESCRIPTION
Instead of waiting new APIs in Reader, this allow a bridge to the old API (publisher).

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #15 
- <kbd>&nbsp;1&nbsp;</kbd> #14 👈 
<!-- GitButler Footer Boundary Bottom -->

