### PR TITLE
Feat/add content dto

### DIFF
--- a/src/lib/omerlo/reader/endpoints/content-templates.ts
+++ b/src/lib/omerlo/reader/endpoints/content-templates.ts
@@ -1,4 +1,6 @@
 import type { LocalesMetadata } from '$reader/utils/response';
+import type { ApiAssocs, ApiData } from '$reader/utils/api';
+import { buildMeta } from '$omerlo/reader/utils/parseHelpers';
 
 export interface ContentTemplate {
   id: string;
@@ -8,11 +10,23 @@ export interface ContentTemplate {
     locales: LocalesMetadata;
   };
   metadata: Record<string, string>;
-  enableFields: string[];
+  enabledFields: string[];
   updatedAt: Date;
 }
 
 export interface ContentBlockTemplate {
   id: string;
   key: string;
+}
+
+export function parseContentTemplate(data: ApiData, _assocs: ApiAssocs): ContentTemplate {
+  return {
+    id: data.id,
+    key: data.key,
+    name: data.localized.name,
+    meta: buildMeta(data.localized.locale),
+    metadata: data.metadata,
+    enabledFields: data.enabled_fields,
+    updatedAt: data.updated_at
+  };
 }

--- a/src/lib/omerlo/reader/endpoints/contents.ts
+++ b/src/lib/omerlo/reader/endpoints/contents.ts
@@ -1,60 +1,335 @@
-import type { LocalesMetadata } from '$reader/utils/response';
 import type { Category } from './categories';
 import type { ContentBlockTemplate, ContentTemplate } from './content-templates';
-import type { Visual } from './visuals';
+import {
+  type Visual,
+  type Slideshow,
+  type Image,
+  type Video,
+  parseVideo,
+  parseImage,
+  parseSlideshow,
+  parseVisual
+} from './visuals';
+import { requestPublisher } from '$reader/utils/request';
+import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
+import { getAssoc, getAssocs } from '$reader/utils/assocs';
+import type { LocalesMetadata } from '$reader/utils/response';
+import { buildMeta, parseDate } from '$omerlo/reader/utils/parseHelpers';
 
-export interface ContentSummary {
-  id: string;
-  template: ContentTemplate;
-  metadata: Record<string, string>;
-  canonicalDomain: string;
-  canonicalUrl: string;
-  isArchived: boolean;
-  publishedAt?: Date;
-  visibility?: string;
-  categories: Category[];
-  show_published_at: boolean;
-  updatedAt: Date;
-  meta: {
-    locales: LocalesMetadata;
+export const contentsFetchers = (f: typeof fetch) => {
+  return {
+    getContent: getContent(f),
+    listContents: listContents(f)
   };
-  titleHtml: string;
-  titleText: string;
-  leadHtml: string;
-  leadText: string;
-  subtitleHtml: string;
-  subtitleText: string;
-  visual: Visual;
-  seo: ContentSeo;
-  // TODO authors
-}
+};
 
 export interface ContentSeo {
   title: string;
   description: string;
 }
 
+export interface ContentSummary {
+  id: string;
+  template: ContentTemplate;
+  canonicalDomain: string | null;
+  canonicalUrl: string | null;
+  publishedAt: Date | null;
+  visibility: string | null;
+  categories: Category[];
+  showPublishedAt: boolean;
+  updatedAt: Date;
+  titleHtml: string;
+  titleText: string;
+  leadHtml: string | null;
+  leadText: string | null;
+  subtitleHtml: string | null;
+  subtitleText: string | null;
+  visual: Visual | null;
+  seo: ContentSeo;
+  meta: {
+    locales: LocalesMetadata;
+  };
+  // TODO: authors
+}
+
 export interface Content extends ContentSummary {
+  metadata: Record<string, string>;
   blocks: ContentBlock[];
 }
 
-export type ContentBlock = ContentBlockRichtext | ContentBlockData;
-
 export type ContentBlockRichtext = {
   id: string;
-  template: ContentBlockTemplate;
-  visual?: Visual;
   kind: 'richtext';
   contentHtml: string;
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
 };
 
 export type ContentBlockData = {
   id: string;
-  template: ContentBlockTemplate;
-  visual?: Visual;
   kind: 'data';
   contentType: string;
   data: unknown;
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
 };
 
-// TODO others content's blocks
+export type ContentBlockHTML = {
+  id: string;
+  kind: 'html';
+  contentHtml: string;
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
+};
+
+export type ContentBlockQuote = {
+  id: string;
+  kind: 'quote';
+  quoteHtml: string;
+  quoteText: string;
+  author: string;
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
+};
+
+export type ContentBlockRelatedContents = {
+  id: string;
+  kind: 'related-contents';
+  contents: Content[];
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
+};
+
+export type Answer = {
+  id: string;
+  contentHtml: string;
+  contentText: string;
+};
+
+export type ContentBlockQuestion = {
+  id: string;
+  kind: 'question';
+  questionHtml: string;
+  questionText: string;
+  acceptVoteUntil: Date;
+  answers: Answer[];
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
+};
+
+export type ContentBlockImage = {
+  id: string;
+  kind: 'image';
+  image: Image;
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
+};
+
+export type ContentBlockSlideshow = {
+  id: string;
+  kind: 'slideshow';
+  slideshow: Slideshow;
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
+};
+
+export type ContentBlockVideo = {
+  id: string;
+  kind: 'video';
+  video: Video;
+  visual: Visual | null;
+  template: ContentBlockTemplate | null;
+};
+
+export type ContentBlock =
+  | ContentBlockRichtext
+  | ContentBlockData
+  | ContentBlockHTML
+  | ContentBlockQuote
+  | ContentBlockRelatedContents
+  | ContentBlockQuestion
+  | ContentBlockImage
+  | ContentBlockSlideshow
+  | ContentBlockVideo;
+
+export type ContentBlockType =
+  | 'richtext'
+  | 'data'
+  | 'html'
+  | 'quote'
+  | 'related-contents'
+  | 'question'
+  | 'image'
+  | 'slideshow'
+  | 'video';
+
+function baseBlock(data: ApiData, assocs: ApiAssocs) {
+  return {
+    id: data.id,
+    kind: data.kind,
+    template: getBlockTemplate(data, assocs),
+    visual: parseVisual(data.visual, assocs)
+  };
+}
+
+export function getContent(f: typeof fetch) {
+  return async (id: string) => {
+    const opts = { parser: parseContent };
+    return requestPublisher(f, `/contents/${id}`, opts);
+  };
+}
+
+export function listContents(f: typeof fetch) {
+  return async (params?: Partial<PagingParams>) => {
+    const queryParams = params;
+    const opts = { parser: parseMany(parseContentSummary), queryParams };
+    return requestPublisher(f, `/contents`, opts);
+  };
+}
+
+export function parseContentSummary(data: ApiData, assocs: ApiAssocs): ContentSummary {
+  return {
+    id: data.id,
+    template: getAssoc<ContentTemplate>(assocs, 'templates', data.template_id),
+    canonicalDomain: data.canonical_domain,
+    canonicalUrl: data.canonical_url,
+    publishedAt: parseDate(data.published_at),
+    visibility: data.visibility,
+    categories: getAssocs<Category>(assocs, 'categories', data.category_ids),
+    showPublishedAt: data.show_published_at,
+    updatedAt: new Date(data.updated_at),
+    titleHtml: data.localized.title_html,
+    titleText: data.localized.title_text,
+    leadHtml: data.localized.lead_html,
+    leadText: data.localized.lead_text,
+    subtitleHtml: data.localized.subtitle_html,
+    subtitleText: data.localized.subtitle_text,
+    seo: {
+      title: data.localized.seo.title,
+      description: data.localized.seo.description
+    },
+    visual: parseVisual(data.visual, assocs),
+    meta: buildMeta(data.localized.locale)
+  };
+}
+
+export function parseContent(data: ApiData, assocs: ApiAssocs): Content {
+  return {
+    ...parseContentSummary(data, assocs),
+    metadata: data.metadata,
+    blocks: data.localized.blocks
+      .map((block: ApiData) => parseContentBlock(block, assocs))
+      .filter(Boolean) as ContentBlock[]
+  };
+}
+
+const ContentBlockParser: Record<
+  ContentBlockType,
+  (block: ApiData, _assocs: ApiAssocs) => ContentBlock
+> = {
+  richtext: parseContentBlockRichtext,
+  data: parseContentBlockData,
+  html: parseContentBlockHTML,
+  quote: parseContentBlockQuote,
+  'related-contents': parseContentBlockRelatedContents,
+  question: parseContentBlockQuestion,
+  image: parseContentBlockImage,
+  slideshow: parseContentBlockSlideshow,
+  video: parseContentBlockVideo
+};
+
+export function parseContentBlock(block: ApiData, assocs: ApiAssocs): ContentBlock | null {
+  const parser = ContentBlockParser[block.kind as ContentBlockType];
+  return parser ? parser(block, assocs) : null;
+}
+
+function getBlockTemplate(data: ApiData, assocs: ApiAssocs): ContentBlockTemplate | null {
+  return data.template_id
+    ? getAssoc<ContentBlockTemplate>(assocs, 'block_templates', data.template_id)
+    : null;
+}
+
+function getBlockContent(data: ApiData, assocs: ApiAssocs): Content[] | [] {
+  return data.related_contents ? getAssocs<Content>(assocs, 'contents', data.related_contents) : [];
+}
+
+function parseContentBlockRichtext(data: ApiData, assocs: ApiAssocs): ContentBlockRichtext {
+  return {
+    ...baseBlock(data, assocs),
+    contentHtml: data.content_html
+  };
+}
+
+function parseContentBlockData(data: ApiData, assocs: ApiAssocs): ContentBlockData {
+  return {
+    ...baseBlock(data, assocs),
+    contentType: data.content_type,
+    data: data.data
+  };
+}
+
+function parseContentBlockHTML(data: ApiData, assocs: ApiAssocs): ContentBlockHTML {
+  return {
+    ...baseBlock(data, assocs),
+    contentHtml: data.content_html
+  };
+}
+
+function parseContentBlockQuote(data: ApiData, assocs: ApiAssocs): ContentBlockQuote {
+  return {
+    ...baseBlock(data, assocs),
+    quoteHtml: data.quote_html,
+    quoteText: data.quote_text,
+    author: data.author
+  };
+}
+
+function parseContentBlockRelatedContents(
+  data: ApiData,
+  assocs: ApiAssocs
+): ContentBlockRelatedContents {
+  const contents = getBlockContent(data, assocs);
+  return {
+    ...baseBlock(data, assocs),
+    contents
+  };
+}
+
+function parseContentBlockQuestion(data: ApiData, assocs: ApiAssocs): ContentBlockQuestion {
+  return {
+    ...baseBlock(data, assocs),
+    questionHtml: data.question_html,
+    questionText: data.question_text,
+    acceptVoteUntil: new Date(data.accept_vote_until),
+    answers: data.answers?.map((answer: ApiData) => parseAnswer(answer)) || []
+  };
+}
+
+function parseAnswer(data: ApiData): Answer {
+  return {
+    id: data.id,
+    contentHtml: data.content_html,
+    contentText: data.content_text
+  };
+}
+
+function parseContentBlockImage(data: ApiData, assocs: ApiAssocs): ContentBlockImage {
+  return {
+    ...baseBlock(data, assocs),
+    image: parseImage(data.image, assocs)
+  };
+}
+
+function parseContentBlockSlideshow(data: ApiData, assocs: ApiAssocs): ContentBlockSlideshow {
+  return {
+    ...baseBlock(data, assocs),
+    slideshow: parseSlideshow(data.slideshow, assocs)
+  };
+}
+
+function parseContentBlockVideo(data: ApiData, assocs: ApiAssocs): ContentBlockVideo {
+  return {
+    ...baseBlock(data, assocs),
+    video: parseVideo(data.video, assocs)
+  };
+}

--- a/src/lib/omerlo/reader/endpoints/notification.ts
+++ b/src/lib/omerlo/reader/endpoints/notification.ts
@@ -20,7 +20,7 @@ export function listTopics(f: typeof fetch) {
 export function parseTopicSummary(data: ApiData, _assocs: ApiAssocs): TopicSummary {
   return {
     id: data.id,
-    name: data.localized.name,
+    name: data.name,
     meta: {
       locales: parseLocalesMetadata(data.meta)
     },

--- a/src/lib/omerlo/reader/endpoints/visuals.ts
+++ b/src/lib/omerlo/reader/endpoints/visuals.ts
@@ -50,9 +50,10 @@ const VisualParser: Record<VisualType, (data: ApiData, _assocs: ApiAssocs) => Vi
   video: parseVideo
 };
 
-export function parseVisual(data: ApiData, _assocs: ApiAssocs): Visual | null {
-  const parser = VisualParser[data.type as VisualType];
-  return parser ? parser(data, _assocs) : null;
+export function parseVisual(data: ApiData, assocs: ApiAssocs): Visual | null {
+  const type = data?.type as VisualType;
+  if (!type) return null;
+  return VisualParser[type]?.(data, assocs) ?? null;
 }
 
 export function parseImage(data: ApiData, _assocs: ApiAssocs): Image {
@@ -65,11 +66,11 @@ export function parseImage(data: ApiData, _assocs: ApiAssocs): Image {
     gravity: data.gravity
   };
 }
-export function parseSlideshow(data: ApiData, _assocs: ApiAssocs): Slideshow {
+export function parseSlideshow(data: ApiData, assocs: ApiAssocs): Slideshow {
   return {
     type: 'slideshow',
     images: Array.isArray(data.images)
-      ? data.images.map((imageData: ApiData) => parseImage(imageData, _assocs))
+      ? data.images.map((imageData: ApiData) => parseImage(imageData, assocs))
       : []
   };
 }

--- a/src/lib/omerlo/reader/fetchers.ts
+++ b/src/lib/omerlo/reader/fetchers.ts
@@ -1,12 +1,12 @@
 import { accountsFetchers } from './endpoints/accounts';
 import { categoriesFetchers } from './endpoints/categories';
 import { deviceFetchers } from './endpoints/device';
-import { mediaBlockFetchers } from './endpoints/media-block';
 import { notificationFetchers } from './endpoints/notification';
 import { oauthFetchers } from './endpoints/oauth';
 import { personFetchers } from './endpoints/person';
 import { projectFetchers } from './endpoints/projects';
 import { eventFetchers } from './endpoints/events';
+import { contentsFetchers } from './endpoints/contents';
 
 export const fetchers = (f: typeof fetch) => {
   return {
@@ -17,7 +17,7 @@ export const fetchers = (f: typeof fetch) => {
     ...personFetchers(f),
     ...projectFetchers(f),
     ...eventFetchers(f),
-    ...mediaBlockFetchers(f),
+    ...contentsFetchers(f),
     notifications: notificationFetchers(f)
   };
 };

--- a/src/lib/omerlo/reader/index.ts
+++ b/src/lib/omerlo/reader/index.ts
@@ -1,5 +1,6 @@
 import { parseCategory } from './endpoints/categories';
 import { parseProfileSummary } from './endpoints/profiles';
+import { parseContentTemplate } from './endpoints/content-templates';
 import { registerAssocParser } from './utils/assocs';
 
 export * from './stores/user_session';
@@ -8,3 +9,4 @@ export type * from './endpoints/accounts';
 
 registerAssocParser('categories', parseCategory);
 registerAssocParser('profiles', parseProfileSummary);
+registerAssocParser('templates', parseContentTemplate);

--- a/src/lib/omerlo/reader/utils/parseHelpers.ts
+++ b/src/lib/omerlo/reader/utils/parseHelpers.ts
@@ -1,0 +1,14 @@
+export function buildMeta(locale: string) {
+  return {
+    locales: {
+      available: [locale],
+      current: locale
+    }
+  };
+}
+
+export function parseDate(input?: string | null): Date | null {
+  if (!input) return null;
+  const date = new Date(input);
+  return isNaN(date.getTime()) ? null : date;
+}


### PR DESCRIPTION
* Added extensive parsing logic for `Content`, `ContentSummary`, and various `ContentBlock` types, including rich text, HTML, quotes, images, slideshows, and videos. This includes new parsing functions like `parseContent`, `parseContentSummary`, and `parseContentBlock` to handle API data and associations.
* Introduced `contentsFetchers` to manage fetching content and content lists, and integrated it into the main `fetchers` module.
* Updated the `Category` interface to replace `locale` with `locales` for consistency.
* Modified `ContentBlockTemplate` and `ContentBlock` types to include nullable `template` fields and added new `ContentBlock` variants (e.g., `ContentBlockHTML`, `ContentBlockQuote`).
* Added `registerAssocParser` to dynamically register parsers for API associations and integrated it for `ContentTemplate` parsing.