### PR TITLE
feat: Add profile type fetchers and parsing functions

### DIFF
--- a/src/lib/omerlo/reader/endpoints/events.ts
+++ b/src/lib/omerlo/reader/endpoints/events.ts
@@ -2,8 +2,9 @@ import type { Category } from './categories';
 import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
 import { requestPublisher } from '$reader/utils/request';
 import type { LocalesMetadata } from '$reader/utils/response';
-import { getAssocs } from '../utils/assocs';
+import { getAssoc, getAssocs } from '../utils/assocs';
 import { parseProfileAddress, type ProfileAddress } from './profiles';
+import type { ProfileType } from './profileType';
 
 export const eventFetchers = (f: typeof fetch) => {
   return {
@@ -14,7 +15,7 @@ export const eventFetchers = (f: typeof fetch) => {
 
 export interface EventSummary {
   id: string;
-  // profileType: string;
+  profileType: ProfileType;
   kind: string;
   type: string;
   isAllDay: boolean;
@@ -39,9 +40,10 @@ export interface Event extends EventSummary {
   description: unknown;
 }
 
-export function parseEventSummary(data: ApiData, _assocs: ApiAssocs): EventSummary {
+export function parseEventSummary(data: ApiData, assocs: ApiAssocs): EventSummary {
   return {
     id: data.id,
+    profileType: getAssoc<ProfileType>(assocs, 'profile_types', data.profile_type_id),
     kind: 'event',
     type: data.type,
     isAllDay: data.is_all_day,

--- a/src/lib/omerlo/reader/endpoints/profileType.ts
+++ b/src/lib/omerlo/reader/endpoints/profileType.ts
@@ -1,0 +1,79 @@
+import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
+import type { LocalesMetadata } from '$reader/utils/response';
+import { requestPublisher } from '$reader/utils/request';
+import { buildMeta } from '../utils/parseHelpers';
+
+
+export const profileTypeFetchers = (f: typeof fetch) => {
+  return {
+    getProfileType: getProfileType(f),
+    listProfileTypes: listProfileTypes(f)
+  };
+};
+
+export interface ProfileTypeSummary {
+  id: string;
+  kind: 'person' | 'project' | 'organization' | 'event';
+  key: string | null;
+  name: string;
+  meta: {
+    locales: LocalesMetadata;
+  };
+  updatedAt: Date;
+}
+
+export function parseProfileTypeSummary(data: ApiData, _assocs: ApiAssocs): ProfileTypeSummary {
+  return {
+    id: data.id,
+    kind: data.kind,
+    key: data.key,
+    name: data.localized.name,
+    meta: buildMeta(data.localized.locale),
+    updatedAt: new Date(data.updated_at)
+  };
+}
+
+export interface ProfileType extends ProfileTypeSummary {
+  hasPhone: boolean;
+  hasEmail: boolean;
+  hasLinkedIn: boolean;
+  hasWebsite: boolean;
+  hasTwitter: boolean;
+  hasFacebook: boolean;
+  hasBlueSky: boolean;
+  hasCountry: boolean;
+  hasState: boolean;
+  hasCity: boolean;
+  hasStreet: boolean;
+}
+
+export function parseProfileType(data: ApiData, assocs: ApiAssocs): ProfileType {
+  return {
+    ...parseProfileTypeSummary(data, assocs),
+    hasPhone: data.has_phone || false,
+    hasEmail: data.has_email || false,
+    hasLinkedIn: data.has_linkedin || false,
+    hasWebsite: data.has_website || false,
+    hasTwitter: data.has_twitter || false,
+    hasFacebook: data.has_facebook || false,
+    hasBlueSky: data.has_bluesky || false,
+    hasCountry: data.has_country || false,
+    hasState: data.has_state || false,
+    hasCity: data.has_city || false,
+    hasStreet: data.has_street || false
+  };
+}
+
+export function getProfileType(f: typeof fetch) {
+  return async (id: string) => {
+    const opts = { parser: parseProfileType };
+    return requestPublisher(f, `/profile-types/${id}`, opts);
+  };
+}
+
+export function listProfileTypes(f: typeof fetch) {
+  return async (params?: Partial<PagingParams>) => {
+    const opts = { parser: parseMany(parseProfileTypeSummary), queryParams: params };
+    return requestPublisher(f, `/profile-types`, opts);
+  };
+}

--- a/src/lib/omerlo/reader/fetchers.ts
+++ b/src/lib/omerlo/reader/fetchers.ts
@@ -8,6 +8,7 @@ import { projectFetchers } from './endpoints/projects';
 import { eventFetchers } from './endpoints/events';
 import { contentsFetchers } from './endpoints/contents';
 import { organizationFetchers } from './endpoints/organizations';
+import { profileTypeFetchers } from './endpoints/profileType';
 
 export const fetchers = (f: typeof fetch) => {
   return {
@@ -20,6 +21,7 @@ export const fetchers = (f: typeof fetch) => {
     ...eventFetchers(f),
     ...contentsFetchers(f),
     ...organizationFetchers(f),
+    ...profileTypeFetchers(f),
     notifications: notificationFetchers(f)
   };
 };

--- a/src/lib/omerlo/reader/index.ts
+++ b/src/lib/omerlo/reader/index.ts
@@ -1,6 +1,7 @@
 import { parseCategory } from './endpoints/categories';
 import { parseProfileSummary } from './endpoints/profiles';
 import { parseContentTemplate } from './endpoints/content-templates';
+import { parseProfileTypeSummary } from './endpoints/profileType';
 import { registerAssocParser } from './utils/assocs';
 
 export * from './stores/user_session';
@@ -10,3 +11,4 @@ export type * from './endpoints/accounts';
 registerAssocParser('categories', parseCategory);
 registerAssocParser('profiles', parseProfileSummary);
 registerAssocParser('templates', parseContentTemplate);
+registerAssocParser('profile_types', parseProfileTypeSummary);


### PR DESCRIPTION
* Created a new `ProfileType` model with detailed attributes and parsing logic in `src/lib/omerlo/reader/endpoints/profileType.ts`. This includes methods for fetching single and multiple profile types.


* Updated the `EventSummary` interface in `src/lib/omerlo/reader/endpoints/events.ts` to include a `profileType` field of type `ProfileType`.
* Modified the `parseEventSummary` function to retrieve the `ProfileType` using the `getAssoc` utility.


* Added `profileTypeFetchers` to the fetcher system in `src/lib/omerlo/reader/fetchers.ts`.
* Registered a new parser for `profile_types` in `src/lib/omerlo/reader/index.ts` to handle associations.