### PR TITLE
refactor: update data fields with new parsing functions and fixes

### DIFF
--- a/src/lib/omerlo/reader/endpoints/categories.ts
+++ b/src/lib/omerlo/reader/endpoints/categories.ts
@@ -1,6 +1,7 @@
 import { type LocalesMetadata } from '$reader/utils/response';
 import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
-import { requestPublisher } from '../utils/request';
+import { requestPublisher } from '$reader/utils/request';
+import { buildMeta } from '$reader/utils/parseHelpers';
 
 export const categoriesFetchers = (f: typeof fetch) => {
   return {
@@ -28,8 +29,7 @@ export function getCategory(f: typeof fetch) {
 
 export function listCategories(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
-    const queryParams = params;
-    const opts = { parser: parseMany(parseCategory), queryParams };
+    const opts = { parser: parseMany(parseCategory), queryParams: params };
     return requestPublisher(f, `/categories`, opts);
   };
 }
@@ -40,11 +40,6 @@ export function parseCategory(data: ApiData, _assoc: ApiAssocs): Category {
     svg: data.svg_icon,
     name: data.localized.name,
     updatedAt: data.updated_at,
-    meta: {
-      locales: {
-        available: [data.localized.locale],
-        current: data.localized.locale
-      }
-    }
+    meta: buildMeta(data.localized.locale)
   };
 }

--- a/src/lib/omerlo/reader/endpoints/content-templates.ts
+++ b/src/lib/omerlo/reader/endpoints/content-templates.ts
@@ -1,6 +1,6 @@
 import type { LocalesMetadata } from '$reader/utils/response';
 import type { ApiAssocs, ApiData } from '$reader/utils/api';
-import { buildMeta } from '$omerlo/reader/utils/parseHelpers';
+import { buildMeta } from '$reader/utils/parseHelpers';
 
 export interface ContentTemplate {
   id: string;
@@ -17,6 +17,21 @@ export interface ContentTemplate {
 export interface ContentBlockTemplate {
   id: string;
   key: string;
+  visual: {
+    allowed_types: string[];
+    is_enabled: boolean;
+  };
+}
+
+export function parseContentBlockTemplate(data: ApiData, _assocs: ApiAssocs): ContentBlockTemplate {
+  return {
+    id: data.id,
+    key: data.key,
+    visual: {
+      allowed_types: data.visual.allowed_types,
+      is_enabled: data.visual.is_enabled
+    }
+  };
 }
 
 export function parseContentTemplate(data: ApiData, _assocs: ApiAssocs): ContentTemplate {

--- a/src/lib/omerlo/reader/endpoints/contents.ts
+++ b/src/lib/omerlo/reader/endpoints/contents.ts
@@ -14,7 +14,7 @@ import { requestPublisher } from '$reader/utils/request';
 import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
 import { getAssoc, getAssocs } from '$reader/utils/assocs';
 import type { LocalesMetadata } from '$reader/utils/response';
-import { buildMeta, parseDate } from '$omerlo/reader/utils/parseHelpers';
+import { buildMeta, parseDate } from '$reader/utils/parseHelpers';
 
 export const contentsFetchers = (f: typeof fetch) => {
   return {
@@ -181,8 +181,7 @@ export function getContent(f: typeof fetch) {
 
 export function listContents(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
-    const queryParams = params;
-    const opts = { parser: parseMany(parseContentSummary), queryParams };
+    const opts = { parser: parseMany(parseContentSummary), queryParams: params };
     return requestPublisher(f, `/contents`, opts);
   };
 }

--- a/src/lib/omerlo/reader/endpoints/events.ts
+++ b/src/lib/omerlo/reader/endpoints/events.ts
@@ -12,7 +12,7 @@ import {
   parseProfileDescription
 } from './profiles';
 import type { ProfileAddress, ProfileContact, ProfileDescription } from './profiles';
-import { buildMeta } from '../utils/parseHelpers';
+import { buildMeta } from '$reader/utils/parseHelpers';
 
 export const eventFetchers = (f: typeof fetch) => {
   return {

--- a/src/lib/omerlo/reader/endpoints/organizations.ts
+++ b/src/lib/omerlo/reader/endpoints/organizations.ts
@@ -1,10 +1,14 @@
-import type { ApiAssocs } from "../utils/api";
-import { type ApiData, parseMany, type PagingParams } from "../utils/api";
-import { getAssocs } from "../utils/assocs";
-import { requestPublisher } from "../utils/request";
-import type { LocalesMetadata } from "../utils/response";
-import type { Category } from "./categories";
-import { parseProfileAddress, type ProfileAddress } from "./profiles";
+import type { ApiAssocs } from '$reader/utils/api';
+import { type ApiData, parseMany, type PagingParams } from '$reader/utils/api';
+import { getAssoc, getAssocs } from '$reader/utils/assocs';
+import { requestPublisher } from '$reader/utils/request';
+import type { LocalesMetadata } from '$reader/utils/response';
+import type { Category } from './categories';
+import { parseProfileAddress, type ProfileAddress } from './profiles';
+import { parseProfileContact, type ProfileContact } from './profiles';
+import { parseProfileDescription, type ProfileDescription } from './profiles';
+import type { ProfileType } from './profileType';
+import { buildMeta } from '$reader/utils/parseHelpers';
 
 export const organizationFetchers = (f: typeof fetch) => {
   return {
@@ -14,65 +18,60 @@ export const organizationFetchers = (f: typeof fetch) => {
 };
 
 export interface OrganizationSummary {
-    id: string;
-    // profileType: ProfileType;
-    kind: string;
-    name: string;
-    logoImgURL: string | null;
-    meta: {
-        locales: LocalesMetadata;
-    };
-    summaryHtml: string | null;
-    summaryText: string | null;
-    updatedAt: Date;
+  id: string;
+  profileType: ProfileType;
+  kind: string;
+  name: string;
+  logoImgURL: string | null;
+  meta: {
+    locales: LocalesMetadata;
+  };
+  summaryHtml: string | null;
+  summaryText: string | null;
+  updatedAt: Date;
 }
 
 export interface Organization extends OrganizationSummary {
-    coverImgURL: string | null;
-    categories: Category[];
-    contact: unknown; // ProfileContact | null;
-    address: ProfileAddress | null;
-    description: unknown; // ProfileDescription | null;
+  coverImgURL: string | null;
+  categories: Category[];
+  contact: ProfileContact | null;
+  address: ProfileAddress | null;
+  description: ProfileDescription | null;
 }
 
 export function parseOrganizationSummary(data: ApiData, _assocs: ApiAssocs): OrganizationSummary {
   return {
-        id: data.id,
-        // profileType: getAssocs<ProfileType>(_assocs, 'profileTypes', data.profile_type_id),
-        kind: 'organization',
-        name: data.name,
-        logoImgURL: data.logo_image_url,
-        meta: {
-            locales: {
-                available: [data.localized.locale],
-                current: data.localized.locale
-            }
-        },
-        summaryHtml: data.localized.summary_html,
-        summaryText: data.localized.summary_text,
-        updatedAt: new Date(data.updated_at)
-    };
+    id: data.id,
+    profileType: getAssoc<ProfileType>(_assocs, 'profile_types', data.profile_type_id),
+    kind: 'organization',
+    name: data.name,
+    logoImgURL: data.logo_image_url,
+    meta: buildMeta(data.localized.locale),
+    summaryHtml: data.localized.summary_html,
+    summaryText: data.localized.summary_text,
+    updatedAt: new Date(data.updated_at)
+  };
 }
 
 export function parseOrganization(data: ApiData, assocs: ApiAssocs): Organization {
-  // const contact = data.localized.contact
-  //   ? parseProfileContact(data.localized.contact, assocs)
-  //   : null;
+  const contact = data.localized.contact
+    ? parseProfileContact(data.localized.contact, assocs)
+    : null;
   const address = data.localized_address
     ? parseProfileAddress(data.localized_address, assocs)
     : null;
-  // const description = data.localized.description
-  //   ? parseProfileDescription(data.localized.description, assocs)
-  //   : null;
+  const description = data.localized.description
+    ? parseProfileDescription(data.localized.description, assocs)
+    : null;
 
   return {
-        ...parseOrganizationSummary(data, assocs),
-        coverImgURL: data.cover_image_url,
-        categories: getAssocs<Category>(assocs, 'categories', data.category_ids),
-        contact: null,
-        address,
-        description: null
-    };
+    ...parseOrganizationSummary(data, assocs),
+    coverImgURL: data.cover_image_url,
+    categories: getAssocs<Category>(assocs, 'categories', data.category_ids),
+    contact,
+    address,
+    description
+  };
 }
 
 export function getOrganization(f: typeof fetch) {

--- a/src/lib/omerlo/reader/endpoints/person.ts
+++ b/src/lib/omerlo/reader/endpoints/person.ts
@@ -1,9 +1,18 @@
 import type { Category } from './categories';
 import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
-import { requestPublisher } from '../utils/request';
+import { requestPublisher } from '$reader/utils/request';
 import type { LocalesMetadata } from '$reader/utils/response';
-import { parseProfileAddress, type ProfileAddress } from './profiles';
-import { getAssocs } from '../utils/assocs';
+import {
+  parseProfileAddress,
+  type ProfileAddress,
+  parseProfileContact,
+  type ProfileContact,
+  parseProfileDescription,
+  type ProfileDescription
+} from './profiles';
+import { getAssoc, getAssocs } from '$reader/utils/assocs';
+import type { ProfileType } from './profileType';
+import { buildMeta } from '$reader/utils/parseHelpers';
 
 export const personFetchers = (f: typeof fetch) => {
   return {
@@ -14,7 +23,7 @@ export const personFetchers = (f: typeof fetch) => {
 
 export interface PersonSummary {
   id: string;
-  //profileType: string;
+  profileType: ProfileType;
   kind: string;
   firstName: string;
   lastName: string;
@@ -22,8 +31,8 @@ export interface PersonSummary {
   pronoun: string | null;
   avatarImageURL: string | null;
   meta: {
-      locales: LocalesMetadata;
-    };
+    locales: LocalesMetadata;
+  };
   summaryHtml: string | null;
   summaryText: string | null;
   updatedAt: Date;
@@ -32,19 +41,14 @@ export interface PersonSummary {
 export function parsePersonSummary(data: ApiData, _assocs: ApiAssocs): PersonSummary {
   return {
     id: data.id,
-    //profileType: data.profile_type_id,
+    profileType: getAssoc<ProfileType>(_assocs, 'profile_types', data.profile_type_id),
     kind: 'person',
     firstName: data.first_name,
     lastName: data.last_name,
     otherName: data.other_name,
     pronoun: data.pronoun,
     avatarImageURL: data.avatar_image_url,
-    meta: {
-      locales: {
-        available: [data.localized.locale],
-        current: data.localized.locale
-      }
-    },
+    meta: buildMeta(data.localized.locale),
     summaryHtml: data.localized.summary_html,
     summaryText: data.localized.summary_text,
     updatedAt: new Date(data.updated_at)
@@ -54,21 +58,27 @@ export function parsePersonSummary(data: ApiData, _assocs: ApiAssocs): PersonSum
 export interface Person extends PersonSummary {
   categories: Category[];
   address: ProfileAddress | null;
-  contact: unknown;
-  description: unknown;
+  contact: ProfileContact | null;
+  description: ProfileDescription | null;
 }
 
 export function parsePerson(data: ApiData, assocs: ApiAssocs): Person {
   const address = data.localized_address
     ? parseProfileAddress(data.localized_address, assocs)
     : null;
+  const contact = data.localized_contact
+    ? parseProfileContact(data.localized_contact, assocs)
+    : null;
+  const description = data.localized_description
+    ? parseProfileDescription(data.localized_description, assocs)
+    : null;
 
   return {
     ...parsePersonSummary(data, assocs),
-    categories: getAssocs<Category>(assocs,'categories', data.categories_ids),
+    categories: getAssocs<Category>(assocs, 'categories', data.category_ids),
     address,
-    contact: null,
-    description: null,
+    contact,
+    description
   };
 }
 
@@ -81,8 +91,7 @@ export function getPerson(f: typeof fetch) {
 
 export function listPersons(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
-    const queryParams = params;
-    const opts = { parser: parseMany(parsePersonSummary), queryParams };
+    const opts = { parser: parseMany(parsePersonSummary), queryParams: params };
     return requestPublisher(f, `/people`, opts);
   };
 }

--- a/src/lib/omerlo/reader/endpoints/profileType.ts
+++ b/src/lib/omerlo/reader/endpoints/profileType.ts
@@ -1,8 +1,7 @@
 import { parseMany, type ApiAssocs, type ApiData, type PagingParams } from '$reader/utils/api';
 import type { LocalesMetadata } from '$reader/utils/response';
 import { requestPublisher } from '$reader/utils/request';
-import { buildMeta } from '../utils/parseHelpers';
-
+import { buildMeta } from '$reader/utils/parseHelpers';
 
 export const profileTypeFetchers = (f: typeof fetch) => {
   return {

--- a/src/lib/omerlo/reader/endpoints/profiles.ts
+++ b/src/lib/omerlo/reader/endpoints/profiles.ts
@@ -1,7 +1,7 @@
 import { parsePersonSummary, type PersonSummary } from './person';
 import { parseProjectSummary, type ProjectSummary } from './projects';
 import { parseEventSummary, type EventSummary } from './events';
-import { parseOrganizationSummary, type OrganizationSummary} from './organizations';
+import { parseOrganizationSummary, type OrganizationSummary } from './organizations';
 import type { ApiAssocs, ApiData } from '$reader/utils/api';
 import type { LocalesMetadata } from '$reader/utils/response';
 import { getAssocs } from '$reader/utils/assocs';
@@ -17,6 +17,7 @@ import {
 import { buildMeta } from '$reader/utils/parseHelpers';
 
 export type ProfileSummary = PersonSummary | ProjectSummary | EventSummary | OrganizationSummary;
+export type ProfileBlockKind = ProfileBlockContents | ProfileBlockRelations;
 
 type ProfileKind = 'person' | 'project' | 'event' | 'organization';
 
@@ -33,7 +34,6 @@ function getProfileParser(): Record<
 }
 
 export function parseProfileSummary(data: ApiData, assocs: ApiAssocs): ProfileSummary {
-  
   const profileParser = getProfileParser();
   const parser = profileParser[data.kind as ProfileKind];
 
@@ -67,10 +67,10 @@ export interface ProfileDescription {
   meta: {
     locales: LocalesMetadata;
   };
-  blocks: profileDescriptionBlock[];
+  blocks: ProfileDescriptionBlock[];
 }
 
-export type profileDescriptionBlock = {
+export type ProfileDescriptionBlock = {
   kind: string;
   contentHtml: string;
   contentText: string;
@@ -100,7 +100,7 @@ export interface ProfileBlockRelations extends ProfileBlock {
   profiles: ProfileSummary[];
 }
 
-export function parseProfileBlock(data: ApiData, assocs: ApiAssocs): ProfileBlockContents | ProfileBlockRelations {
+export function parseProfileBlock(data: ApiData, assocs: ApiAssocs): ProfileBlockKind {
   if (data.kind === 'selected_content') {
     const contents = data.content_ids
       ? getAssocs<Content>(assocs, 'contents', data.content_ids)
@@ -131,7 +131,7 @@ function profileBlockParser(data: ApiData, _assocs: ApiAssocs): ProfileBlock {
     profileBlockType: data.block_type_id,
     meta,
     name,
-    updatedAt: data.updated_at
+    updatedAt: new Date(data.updated_at)
   };
 }
 
@@ -158,7 +158,10 @@ export function parseProfileContact(data: ApiData, _assocs: ApiAssocs): ProfileC
   };
 }
 
-export function parseProfileDescriptionBlock(data: ApiData, assocs: ApiAssocs): profileDescriptionBlock {
+export function parseProfileDescriptionBlock(
+  data: ApiData,
+  assocs: ApiAssocs
+): ProfileDescriptionBlock {
   const image = data.image ? parseImage(data.image, assocs) : null;
   const slideshow = data.slideshow ? parseSlideshow(data.slideshow, assocs) : null;
   const video = data.video ? parseVideo(data.video, assocs) : null;
@@ -173,9 +176,9 @@ export function parseProfileDescriptionBlock(data: ApiData, assocs: ApiAssocs): 
   };
 }
 
-export function parseProfileDescription(data: ApiData, _assocs: ApiAssocs): ProfileDescription {
+export function parseProfileDescription(data: ApiData, assocs: ApiAssocs): ProfileDescription {
   const blocks = data.blocks
-    ? data.blocks.map((block: ApiData) => parseProfileDescriptionBlock(block, _assocs))
+    ? data.blocks.map((block: ApiData) => parseProfileDescriptionBlock(block, assocs))
     : [];
 
   return {

--- a/src/lib/omerlo/reader/endpoints/projects.ts
+++ b/src/lib/omerlo/reader/endpoints/projects.ts
@@ -1,9 +1,18 @@
 import type { LocalesMetadata } from '$reader/utils/response';
 import type { Category } from './categories';
-import { parseProfileAddress, type ProfileAddress } from './profiles';
+import {
+  parseProfileAddress,
+  type ProfileAddress,
+  parseProfileContact,
+  type ProfileContact,
+  parseProfileDescription,
+  type ProfileDescription
+} from './profiles';
 import { type ApiData, parseMany, type PagingParams, type ApiAssocs } from '$reader/utils/api';
-import { getAssocs } from '$reader/utils/assocs';
+import { getAssoc, getAssocs } from '$reader/utils/assocs';
 import { requestPublisher } from '$reader/utils/request';
+import { buildMeta } from '$reader/utils/parseHelpers';
+import type { ProfileType } from './profileType';
 
 export const projectFetchers = (f: typeof fetch) => {
   return {
@@ -14,10 +23,10 @@ export const projectFetchers = (f: typeof fetch) => {
 
 export interface ProjectSummary {
   id: string;
-  profileTypeId: string;
+  profileType: ProfileType;
   kind: string;
   logoImgUrl: string | null;
-  meta : {
+  meta: {
     locales: LocalesMetadata;
   };
   name: string;
@@ -26,45 +35,46 @@ export interface ProjectSummary {
   updatedAt: Date;
 }
 
-export function parseProjectSummary(data: ApiData, _assocs: ApiAssocs): ProjectSummary {
+export function parseProjectSummary(data: ApiData, assocs: ApiAssocs): ProjectSummary {
   return {
     id: data.id,
-    profileTypeId: data.profile_type_id,
+    profileType: getAssoc<ProfileType>(assocs, 'profile_types', data.profile_type_id),
     kind: 'project',
     logoImgUrl: data.logo_image_url,
-    meta: {
-      locales: {
-        available: [data.localized.locale],
-        current: data.localized.locale
-      }
-    },
+    meta: buildMeta(data.localized),
     name: data.localized.name,
     summaryHtml: data.localized.summary_html,
     summaryText: data.localized.summary_text,
-    updatedAt: new Date(data.updated_at),
+    updatedAt: new Date(data.updated_at)
   };
 }
 
 export interface Project extends ProjectSummary {
   coverImgUrl: string | null;
   categories: Category[];
-  contact: unknown;
+  contact: ProfileContact | null;
   address: ProfileAddress | null;
-  description: unknown;
+  description: ProfileDescription | null;
 }
 
 export function parseProject(data: ApiData, assocs: ApiAssocs): Project {
+  const contact = data.localized_contact
+    ? parseProfileContact(data.localized_contact, assocs)
+    : null;
   const address = data.localized_address
-   ? parseProfileAddress(data.localized_address, assocs)
+    ? parseProfileAddress(data.localized_address, assocs)
+    : null;
+  const description = data.localized_description
+    ? parseProfileDescription(data.localized_description, assocs)
     : null;
 
   return {
     ...parseProjectSummary(data, assocs),
     coverImgUrl: data.cover_image_url,
     categories: getAssocs<Category>(assocs, 'categories', data.category_ids),
-    contact: null,
+    contact,
     address,
-    description: null,
+    description
   };
 }
 
@@ -77,8 +87,7 @@ export function getProject(f: typeof fetch) {
 
 export function listProjects(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
-    const queryParams = params;
-    const opts = { parser: parseMany(parseProjectSummary), queryParams };
+    const opts = { parser: parseMany(parseProjectSummary), queryParams: params };
     return requestPublisher(f, `/projects`, opts);
   };
 }

--- a/src/lib/omerlo/reader/endpoints/visuals.ts
+++ b/src/lib/omerlo/reader/endpoints/visuals.ts
@@ -1,4 +1,4 @@
-import type { ApiAssocs, ApiData } from '../utils/api';
+import type { ApiAssocs, ApiData } from '$reader/utils/api';
 
 export type Visual = Image | Slideshow | Video;
 

--- a/src/lib/omerlo/reader/index.ts
+++ b/src/lib/omerlo/reader/index.ts
@@ -1,6 +1,6 @@
 import { parseCategory } from './endpoints/categories';
-import { parseProfileSummary } from './endpoints/profiles';
-import { parseContentTemplate } from './endpoints/content-templates';
+import { parseProfileBlock, parseProfileSummary } from './endpoints/profiles';
+import { parseContentBlockTemplate, parseContentTemplate } from './endpoints/content-templates';
 import { parseProfileTypeSummary } from './endpoints/profileType';
 import { registerAssocParser } from './utils/assocs';
 
@@ -12,3 +12,5 @@ registerAssocParser('categories', parseCategory);
 registerAssocParser('profiles', parseProfileSummary);
 registerAssocParser('templates', parseContentTemplate);
 registerAssocParser('profile_types', parseProfileTypeSummary);
+registerAssocParser('profile_block_types', parseProfileBlock);
+registerAssocParser('block_templates', parseContentBlockTemplate);


### PR DESCRIPTION
* Updated all relative imports to absolute imports using the `$reader`.
* Replaced inline metadata parsing logic with the reusable `buildMeta` helper function.
* Replaced `unknown` or commented-out types with specific type definitions (e.g., `ProfileContact`, `ProfileDescription`, `ProfileType`) in all interfaces.
* Refactored parsing functions.
* Standardized the way query parameters are passed by directly assigning `params` to `queryParams` in fetcher functions.