### PR TITLE
refactor: update API endpoints to use 'media' prefix

### DIFF
--- a/src/lib/omerlo/reader/endpoints/categories.ts
+++ b/src/lib/omerlo/reader/endpoints/categories.ts
@@ -23,14 +23,14 @@ export interface Category {
 export function getCategory(f: typeof fetch) {
   return async (id: string) => {
     const opts = { parser: parseCategory };
-    return requestPublisher(f, `/categories/${id}`, opts);
+    return requestPublisher(f, `media/categories/${id}`, opts);
   };
 }
 
 export function listCategories(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parseCategory), queryParams: params };
-    return requestPublisher(f, `/categories`, opts);
+    return requestPublisher(f, `media/categories`, opts);
   };
 }
 

--- a/src/lib/omerlo/reader/endpoints/contents.ts
+++ b/src/lib/omerlo/reader/endpoints/contents.ts
@@ -175,14 +175,14 @@ function baseBlock(data: ApiData, assocs: ApiAssocs) {
 export function getContent(f: typeof fetch) {
   return async (id: string) => {
     const opts = { parser: parseContent };
-    return requestPublisher(f, `/contents/${id}`, opts);
+    return requestPublisher(f, `media/contents/${id}`, opts);
   };
 }
 
 export function listContents(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parseContentSummary), queryParams: params };
-    return requestPublisher(f, `/contents`, opts);
+    return requestPublisher(f, `media/contents`, opts);
   };
 }
 

--- a/src/lib/omerlo/reader/endpoints/events.ts
+++ b/src/lib/omerlo/reader/endpoints/events.ts
@@ -95,20 +95,20 @@ export function parseEvent(data: ApiData, assocs: ApiAssocs): Event {
 export function getEvent(f: typeof fetch) {
   return async (id: string) => {
     const opts = { parser: parseEvent };
-    return requestPublisher(f, `/events/${id}`, opts);
+    return requestPublisher(f, `media/events/${id}`, opts);
   };
 }
 
 export function listEvents(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parseEventSummary), queryParams: params };
-    return requestPublisher(f, `/events`, opts);
+    return requestPublisher(f, `media/events`, opts);
   };
 }
 
 export function listEventBlocks(f: typeof fetch) {
   return async (id: string, params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parseProfileBlock), queryParams: params };
-    return requestPublisher(f, `/events/${id}/blocks`, opts);
+    return requestPublisher(f, `media/events/${id}/blocks`, opts);
   };
 }

--- a/src/lib/omerlo/reader/endpoints/organizations.ts
+++ b/src/lib/omerlo/reader/endpoints/organizations.ts
@@ -77,13 +77,13 @@ export function parseOrganization(data: ApiData, assocs: ApiAssocs): Organizatio
 export function getOrganization(f: typeof fetch) {
   return async (id: string) => {
     const opts = { parser: parseOrganization };
-    return requestPublisher(f, `/organizations/${id}`, opts);
+    return requestPublisher(f, `media/organizations/${id}`, opts);
   };
 }
 
 export function listOrganizations(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parseOrganizationSummary), queryParams: params };
-    return requestPublisher(f, `/organizations`, opts);
+    return requestPublisher(f, `media/organizations`, opts);
   };
 }

--- a/src/lib/omerlo/reader/endpoints/person.ts
+++ b/src/lib/omerlo/reader/endpoints/person.ts
@@ -85,13 +85,13 @@ export function parsePerson(data: ApiData, assocs: ApiAssocs): Person {
 export function getPerson(f: typeof fetch) {
   return async (id: string) => {
     const opts = { parser: parsePerson };
-    return requestPublisher(f, `/people/${id}`, opts);
+    return requestPublisher(f, `media/people/${id}`, opts);
   };
 }
 
 export function listPersons(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parsePersonSummary), queryParams: params };
-    return requestPublisher(f, `/people`, opts);
+    return requestPublisher(f, `media/people`, opts);
   };
 }

--- a/src/lib/omerlo/reader/endpoints/profileType.ts
+++ b/src/lib/omerlo/reader/endpoints/profileType.ts
@@ -66,13 +66,13 @@ export function parseProfileType(data: ApiData, assocs: ApiAssocs): ProfileType 
 export function getProfileType(f: typeof fetch) {
   return async (id: string) => {
     const opts = { parser: parseProfileType };
-    return requestPublisher(f, `/profile-types/${id}`, opts);
+    return requestPublisher(f, `media/profile-types/${id}`, opts);
   };
 }
 
 export function listProfileTypes(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parseProfileTypeSummary), queryParams: params };
-    return requestPublisher(f, `/profile-types`, opts);
+    return requestPublisher(f, `media/profile-types`, opts);
   };
 }

--- a/src/lib/omerlo/reader/endpoints/projects.ts
+++ b/src/lib/omerlo/reader/endpoints/projects.ts
@@ -81,13 +81,13 @@ export function parseProject(data: ApiData, assocs: ApiAssocs): Project {
 export function getProject(f: typeof fetch) {
   return async (id: string) => {
     const opts = { parser: parseProject };
-    return requestPublisher(f, `/projects/${id}`, opts);
+    return requestPublisher(f, `media/projects/${id}`, opts);
   };
 }
 
 export function listProjects(f: typeof fetch) {
   return async (params?: Partial<PagingParams>) => {
     const opts = { parser: parseMany(parseProjectSummary), queryParams: params };
-    return requestPublisher(f, `/projects`, opts);
+    return requestPublisher(f, `media/projects`, opts);
   };
 }

--- a/src/lib/omerlo/reader/index.ts
+++ b/src/lib/omerlo/reader/index.ts
@@ -3,6 +3,7 @@ import { parseProfileBlock, parseProfileSummary } from './endpoints/profiles';
 import { parseContentBlockTemplate, parseContentTemplate } from './endpoints/content-templates';
 import { parseProfileTypeSummary } from './endpoints/profileType';
 import { registerAssocParser } from './utils/assocs';
+import { parseContentSummary } from './endpoints/contents';
 
 export * from './stores/user_session';
 export type * from './endpoints/oauth';
@@ -14,3 +15,4 @@ registerAssocParser('templates', parseContentTemplate);
 registerAssocParser('profile_types', parseProfileTypeSummary);
 registerAssocParser('profile_block_types', parseProfileBlock);
 registerAssocParser('block_templates', parseContentBlockTemplate);
+registerAssocParser('contents', parseContentSummary);

--- a/src/lib/omerlo/reader/server/hooks.ts
+++ b/src/lib/omerlo/reader/server/hooks.ts
@@ -63,13 +63,27 @@ export const proxyHook: Handle = async ({ event, resolve }) => {
   }
 
   // TODO remove once every API will be done in Reader
-  if (event.url.pathname.startsWith('/api/publisher')) {
-    const mediaId = env.PRIVATE_OMERLO_MEDIA_ID;
-    event.url.pathname = event.url.pathname.replace(
-      '/api/publisher/',
-      `/api/public/publisher/v2/medias/${mediaId}/`
-    );
-    return handleApiProxy({ event, resolve });
+  if (event.url.pathname.startsWith('/api/publisher/')) {
+    const pathAfterPublisher = event.url.pathname.slice('/api/publisher/'.length);
+
+    const resourceConfigs = {
+      'media/': { idKey: env['PRIVATE_OMERLO_MEDIA_ID'], resourcePath: 'medias' },
+      'organization/': {
+        idKey: env['PRIVATE_OMERLO_ORGANIZATION_ID'],
+        resourcePath: 'organizations'
+      },
+      'issue/': { idKey: env['PRIVATE_OMERLO_ISSUE_ID'], resourcePath: 'issues' }
+    };
+
+    for (const [prefix, config] of Object.entries(resourceConfigs)) {
+      if (pathAfterPublisher.startsWith(prefix)) {
+        event.url.pathname = event.url.pathname.replace(
+          `/api/publisher/${prefix}`,
+          `/api/public/publisher/v2/${config.resourcePath}/${config.idKey}/`
+        );
+        return handleApiProxy({ event, resolve });
+      }
+    }
   }
 
   return resolve(event);


### PR DESCRIPTION
* Modified the proxy hook to accommodate new API routes with `/media` and `/organization` prefixes. Added logic for handling organization-specific paths and default organization IDs.

* Added a new parser registration for `contents` using `parseContentSummary`. 