### PR TITLE
fix: update data types and improve consistency

### DIFF
--- a/src/lib/omerlo/reader/endpoints/content-templates.ts
+++ b/src/lib/omerlo/reader/endpoints/content-templates.ts
@@ -18,8 +18,8 @@ export interface ContentBlockTemplate {
   id: string;
   key: string;
   visual: {
-    allowed_types: string[];
-    is_enabled: boolean;
+    allowedTypes: string[];
+    isEnabled: boolean;
   };
 }
 
@@ -28,8 +28,8 @@ export function parseContentBlockTemplate(data: ApiData, _assocs: ApiAssocs): Co
     id: data.id,
     key: data.key,
     visual: {
-      allowed_types: data.visual.allowed_types,
-      is_enabled: data.visual.is_enabled
+      allowedTypes: data.visual.allowed_types,
+      isEnabled: data.visual.is_enabled
     }
   };
 }

--- a/src/lib/omerlo/reader/endpoints/contents.ts
+++ b/src/lib/omerlo/reader/endpoints/contents.ts
@@ -68,7 +68,7 @@ export type ContentBlockData = {
   id: string;
   kind: 'data';
   contentType: string;
-  data: unknown;
+  data: string;
   visual: Visual | null;
   template: ContentBlockTemplate | null;
 };

--- a/src/lib/omerlo/reader/endpoints/visuals.ts
+++ b/src/lib/omerlo/reader/endpoints/visuals.ts
@@ -3,7 +3,7 @@ import type { ApiAssocs, ApiData } from '$reader/utils/api';
 export type Visual = Image | Slideshow | Video;
 
 export interface Video {
-  type: string;
+  type: 'video';
   url: string;
   captionHtml: string | null;
   captionText: string | null;
@@ -18,12 +18,12 @@ export interface Video {
 }
 
 export interface Slideshow {
-  type: string;
+  type: 'slideshow';
   images: Image[];
 }
 
 export interface Image {
-  type: string;
+  type: 'image';
   url: string;
   captionHtml: string | null;
   captionText: string | null;

--- a/src/lib/omerlo/reader/index.ts
+++ b/src/lib/omerlo/reader/index.ts
@@ -7,8 +7,25 @@ import { parseContentSummary } from './endpoints/contents';
 import { parseIssueBlockConfiguration, parseIssueType } from './endpoints/magazines';
 
 export * from './stores/user_session';
-export type * from './endpoints/oauth';
 export type * from './endpoints/accounts';
+export type * from './endpoints/categories';
+export type * from './endpoints/content-templates';
+export type * from './endpoints/contents';
+export type * from './endpoints/device';
+export type * from './endpoints/events';
+export type * from './endpoints/magazines';
+export type * from './endpoints/media';
+export type * from './endpoints/menu';
+export type * from './endpoints/notification';
+export type * from './endpoints/oauth';
+export type * from './endpoints/organizations';
+export type * from './endpoints/person';
+export type * from './endpoints/profileType';
+export type * from './endpoints/profiles';
+export type * from './endpoints/projects';
+export type * from './endpoints/visuals';
+export type * from './endpoints/webpage';
+export type * from './utils/response';
 
 registerAssocParser('categories', parseCategory);
 registerAssocParser('profiles', parseProfileSummary);


### PR DESCRIPTION
Change the data property type in the contents endpoint from  unknown to string for better type safety. Update the visual  property names in the content template endpoint to use camelCase,  aligning with JavaScript conventions. Expand the exports in the  index file to include additional endpoints, enhancing the module's  API surface and improving code organization.