### PR TITLE
Setup and run format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@omerlo/omerlo-webkit",
-  "version": "0.0.5",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@omerlo/omerlo-webkit",
-      "version": "0.0.5",
+      "version": "0.0.12",
       "license": "ISC",
       "devDependencies": {
         "@sveltejs/adapter-auto": "^3.0.0",

--- a/src/lib/omerlo/reader/endpoints/magazines.ts
+++ b/src/lib/omerlo/reader/endpoints/magazines.ts
@@ -143,10 +143,7 @@ export function parseIssueType(data: ApiData, _assocs: ApiAssocs): IssueType {
   };
 }
 
-export function parseIssueBlockConfiguration(
-  data: ApiData,
-  assocs: ApiAssocs
-): IssueBlockConfiguration {
+export function parseIssueBlockConfiguration(data: ApiData): IssueBlockConfiguration {
   return {
     id: data.id,
     key: data.key,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,4 @@
 import containerQueries from '@tailwindcss/container-queries';
-import forms from '@tailwindcss/forms';
-import typography from '@tailwindcss/typography';
 import type { Config } from 'tailwindcss';
 
 export default {
@@ -10,5 +8,5 @@ export default {
     extend: {}
   },
 
-  plugins: [typography, forms, containerQueries]
+  plugins: [containerQueries]
 } satisfies Config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "outDir": "dist",
     "paths": {
       "$omerlo": ["./src/lib/omerlo"],
-      "$reader/*": ["./src/lib/omerlo/reader/*"],
+      "$reader/*": ["./src/lib/omerlo/reader/*"]
     }
   },
   "include": ["./**/*.svelte", "./**/*.ts", "./**/*.js", ".svelte-kit/ambient.d.ts"]


### PR DESCRIPTION
Linter and format were broken due to non existing tailwind packages
Also run `npm run format` and update depts