### PR TITLE
Ensure content author backward compatibility

### DIFF
--- a/src/lib/omerlo/reader/endpoints/events.ts
+++ b/src/lib/omerlo/reader/endpoints/events.ts
@@ -45,7 +45,8 @@ export function parseEventSummary(data: ApiData, assocs: ApiAssocs): EventSummar
     kind: 'event',
     type: data.type,
     isAllDay: data.is_all_day,
-    profileImageURL: data.logo_image_url,
+    // NOTE remove logo_image_url once using reader api
+    profileImageURL: data.logo_image_url || data.profile_image_url,
     coverImageURL: data.cover_image_url,
     subscriptionURL: data.subscription_url,
     name,

--- a/src/lib/omerlo/reader/endpoints/organizations.ts
+++ b/src/lib/omerlo/reader/endpoints/organizations.ts
@@ -48,7 +48,8 @@ export function parseOrganizationSummary(data: ApiData, assocs: ApiAssocs): Orga
     profileType: getAssoc<ProfileType>(assocs, 'profile_types', data.profile_type_id),
     kind: 'organization',
     name: data.name,
-    profileImageURL: data.logo_image_url,
+    // NOTE remove logo_image_url once using reader api
+    profileImageURL: data.logo_image_url || data.profile_image_url,
     meta: buildMeta(data.localized?.locale),
     summaryHtml: data.localized?.summary_html,
     summaryText: data.localized?.summary_text,

--- a/src/lib/omerlo/reader/endpoints/person.ts
+++ b/src/lib/omerlo/reader/endpoints/person.ts
@@ -40,7 +40,8 @@ export function parsePersonSummary(data: ApiData, assocs: ApiAssocs): PersonSumm
     lastName: data.last_name,
     otherName: data.other_name,
     pronoun: data.pronoun,
-    profileImageURL: data.avatar_image_url,
+    // NOTE remove logo_image_url once using reader api
+    profileImageURL: data.avatar_image_url || data.profile_image_url,
     coverImageURL: data.cover_image_url,
     meta: buildMeta(data.localized?.locale),
     summaryHtml: data.localized?.summary_html,

--- a/src/lib/omerlo/reader/endpoints/projects.ts
+++ b/src/lib/omerlo/reader/endpoints/projects.ts
@@ -33,7 +33,8 @@ export function parseProjectSummary(data: ApiData, assocs: ApiAssocs): ProjectSu
     id: data.id,
     profileType: getAssoc<ProfileType>(assocs, 'profile_types', data.profile_type_id),
     kind: 'project',
-    profileImageURL: data.logo_image_url,
+    // NOTE remove logo_image_url once using reader api
+    profileImageURL: data.logo_image_url || data.profile_image_url,
     coverImageURL: data.cover_image_url,
     meta: buildMeta(data.localized?.locale),
     name: data.localized?.name,


### PR DESCRIPTION
## 📖 Description

While using both Publisher public API V2 and Reader API,
we have a delta for renamed profile field for main image.
This PR brings a quick fix to solve this.

## 📓 References

- Closes OW-49
