### PR TITLE
Fix/assocs parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@omerlo/omerlo-webkit",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@omerlo/omerlo-webkit",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "ISC",
       "devDependencies": {
         "@sveltejs/adapter-auto": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omerlo/omerlo-webkit",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",

--- a/src/lib/omerlo/reader/utils/api.ts
+++ b/src/lib/omerlo/reader/utils/api.ts
@@ -11,8 +11,8 @@ export async function parseApiResponse<T>(
     meta = null;
 
   if (response.ok) {
-    const assocs = initAssocs(payload.assocs);
-    parseAssocs(assocs);
+    let assocs = initAssocs(payload.assocs);
+    assocs = parseAssocs(assocs);
     meta = payload.meta;
     data = parser(payload.data, assocs);
   }

--- a/src/lib/omerlo/reader/utils/assocs.ts
+++ b/src/lib/omerlo/reader/utils/assocs.ts
@@ -57,20 +57,33 @@ export function initAssocs(apiAssocs: ApiAssocs): Record<string, Record<string, 
  * Parse all assocs using an ordering system to prevent any clone.
  */
 export function parseAssocs(apiAssocs: Record<string, Record<string, Assoc>>) {
-  for (const assocName in apiAssocs) {
-    const assocs = apiAssocs[assocName];
+  const assocs: Record<string, Record<string, ApiData>> = {};
 
-    for (const assocId in assocs) {
-      const assoc = assocs[assocId];
+  for (const assocName in apiAssocs) {
+    assocs[assocName] = {};
+
+    for (const assocId in apiAssocs[assocName]) {
+      assocs[assocName][assocId] = {};
+    }
+  }
+
+  for (const assocName in apiAssocs) {
+    const currentApiAssocs = apiAssocs[assocName];
+
+    for (const assocId in currentApiAssocs) {
+      const assoc = currentApiAssocs[assocId];
 
       if (!assocsParsers[assocName]) {
         console.error(`No assoc parser found for ${assocName}`);
         continue;
       }
 
-      assocs[assocId] = assocsParsers[assocName](assoc, apiAssocs);
+      const parsedAssoc = assocsParsers[assocName](assoc, assocs);
+      Object.assign(assocs[assocName][assocId], parsedAssoc);
     }
   }
+
+  return assocs;
 }
 
 export type Assoc = ApiData;


### PR DESCRIPTION
## 📖 Description

The problem was a racing condition because we return new object when we parsed something. So the idea was to create assocs result first with empty object. Then populate it

## 📓 References

- N/a
