### PR TITLE
Content Block Quote optional author

### DIFF
--- a/src/lib/omerlo/reader/endpoints/contents.ts
+++ b/src/lib/omerlo/reader/endpoints/contents.ts
@@ -92,7 +92,7 @@ export type ContentBlockQuote = {
   kind: 'quote';
   quoteHtml: string;
   quoteText: string;
-  author: string;
+  author: string | null;
   visual: Visual | null;
   template: ContentBlockTemplate | null;
 };


### PR DESCRIPTION
## 📖 Description

We missed nullable `author` attribute on Content Block Quote

## 📓 References

None
