### PR TITLE
feat: Add generic fallback for omerlo request

### DIFF
--- a/src/lib/omerlo/reader/endpoints/integration.ts
+++ b/src/lib/omerlo/reader/endpoints/integration.ts
@@ -1,5 +1,5 @@
 import type { ApiAssocs, ApiData } from '$reader/utils/api';
-import { requestPublisher } from '../utils/request';
+import { requestOmerlo } from '../utils/request';
 
 export const integrationFetchers = (f: typeof fetch) => {
   return {
@@ -10,7 +10,7 @@ export const integrationFetchers = (f: typeof fetch) => {
 export function getReference(f: typeof fetch) {
   return async (key: string) => {
     const opts = { parser: parseReference };
-    return requestPublisher(f, `/references/${key}`, opts);
+    return requestOmerlo(f, `/core/v2/references/${key}`, opts);
   };
 }
 

--- a/src/lib/omerlo/reader/server/hooks.ts
+++ b/src/lib/omerlo/reader/server/hooks.ts
@@ -90,6 +90,11 @@ export const proxyHook: Handle = async ({ event, resolve }) => {
     return handleApiProxy({ event, resolve });
   }
 
+  if (event.url.pathname.startsWith('/api/omerlo/')) {
+    event.url.pathname = event.url.pathname.replace('/api/omerlo/', '/api/public/');
+    return handleApiProxy({ event, resolve });
+  }
+
   return resolve(event);
 };
 

--- a/src/lib/omerlo/reader/utils/request.ts
+++ b/src/lib/omerlo/reader/utils/request.ts
@@ -113,3 +113,39 @@ export async function dirtyRequestPublisher(
 
   return f(path.toString(), opts);
 }
+
+/**
+ * NOTE: This is for OLD api and will be removed once every API will
+ * be developped in Reader.
+ */
+
+export async function requestOmerlo<T>(
+  f: typeof fetch,
+  path: string,
+  opts: Partial<FetchOptions<T>>
+): Promise<ApiResponse<T>> {
+  const { body, headers, method, queryParams, parser } = parseRequestOpts(opts);
+  return dirtyRequestOmerlo(f, path, { body, headers, method, queryParams }).then(async (resp) => {
+    return parseApiResponse(resp, parser);
+  });
+}
+
+export async function dirtyRequestOmerlo(
+  f: typeof fetch,
+  path: string,
+  opts: DirtyFetchOptions
+): Promise<Response> {
+  const queryParams = new URLSearchParams();
+
+  path = `/api/omerlo/${path}`;
+
+  if (opts?.queryParams) {
+    Object.entries(opts.queryParams).forEach(([key, value]) => {
+      queryParams.append(key, String(value));
+    });
+
+    path = `${path}?${queryParams}`;
+  }
+
+  return f(path.toString(), opts);
+}


### PR DESCRIPTION
Clearly not the best option. But it’s a good workarround waiting to finish reader api.