### PR TITLE
Missing interface export in content fetcher

### DIFF
--- a/src/lib/omerlo/reader/endpoints/contents.ts
+++ b/src/lib/omerlo/reader/endpoints/contents.ts
@@ -192,7 +192,7 @@ export function getContent(f: typeof fetch) {
   };
 }
 
-interface ListContentParams extends PagingParams {
+export interface ListContentParams extends PagingParams {
   author_ids?: string | null;
   category_ids?: string | null;
 }


### PR DESCRIPTION
## 📖 Description

Apparently, declaring a query params interface requires to be exported